### PR TITLE
Remove Stripe.js hardcoding from checkout

### DIFF
--- a/templates/partials/shoppingcart_base.html.twig
+++ b/templates/partials/shoppingcart_base.html.twig
@@ -7,7 +7,6 @@
     {% do assets.addJs('plugin://shoppingcart/js/shoppingcart_lib.js') %}
     {% do assets.addJs('plugin://shoppingcart/js/shoppingcart_cart.js') %}
     {% do assets.addJs('plugin://shoppingcart/js/shoppingcart_cart_events.js') %}
-    {% do assets.addJs('plugin://shoppingcart/gateways/stripe/script.js') %}
 {% endblock %}
 
 {% block footer %}

--- a/templates/shoppingcart_checkout.html.twig
+++ b/templates/shoppingcart_checkout.html.twig
@@ -15,8 +15,6 @@
     }());
     </script>
 
-    <script src="https://checkout.stripe.com/checkout.js"></script>
-
     <div class="joocommerce-container js__checkout__block">
         <h1>{{ 'PLUGIN_SHOPPINGCART.CHECKOUT_PAGE_TITLE'|t }}</h1>
 


### PR DESCRIPTION
The template file still has Stripe hardcoded in it. Probably not best to do this & leave it to each payment gateway plugin somehow