### PR TITLE
Removed the classless <div> wrapping the proper classed div

### DIFF
--- a/templates/checkout.html.twig
+++ b/templates/checkout.html.twig
@@ -25,9 +25,7 @@
 
         {% for field in form.fields %}
             {% set value = form.value(field.name) %}
-            <div>
                 {% include "forms/fields/#{field.type}/#{field.type}.html.twig" %}
-            </div>
         {% endfor %}
 
           <div class="buttons">


### PR DESCRIPTION
As there are no class to the wrapping div before the include, but proper classes on the child div, there is no reason to wrap it. 
Easier for custom styling so `div:nth-of-type(4)` etc is not needed, pew