### PR TITLE
"Add to cart button" functionality on products list page

### DIFF
--- a/blueprints/pages/shoppingcart_products.yaml
+++ b/blueprints/pages/shoppingcart_products.yaml
@@ -1,0 +1,31 @@
+title: Product
+'@extends':
+    type: default
+    context: blueprints://pages
+
+form:
+  fields:
+    tabs:
+      fields:
+        content:
+          type: tab
+
+          fields:
+
+            product:
+              type: section
+              title: Products options
+              underline: true
+
+              fields:
+                header.display_add_to_cart:
+                  type: toggle
+                  label: Display Add To Cart Button
+                  help: Display "Add to Cart"-button instead of "Details"-button on each product.
+                  highlight: 1
+                  default: 0
+                  options:
+                      1: Yes
+                      0: No
+                  validate:
+                       type: bool

--- a/js/shoppingcart_cart_events.js
+++ b/js/shoppingcart_cart_events.js
@@ -73,11 +73,25 @@
     jQuery(document).on('click tap', '.js__shoppingcart__button-add-to-cart', function(event) {
         var quantity = jQuery(this).closest('.shoppingcart-product-container').find('#js__shoppingcart__quantity').val() || 1;
         var button = jQuery(this);
-        button.attr('disabled', 'disabled');
         var i = 0;
+        var product = {};
+        var currentProduct = [];
+        var clickedId = jQuery(this).data('id');
+        
+        button.attr('disabled', 'disabled');
 
+        if (ShoppingCart.currentPageIsProducts) {
+            currentProduct = ShoppingCart.currentProducts.filter(filterById);
+            ShoppingCart.currentProduct = currentProduct[0];
+        }
+
+        function filterById(item) {
+            return item.id == clickedId;
+        }
+        
         // Deep copy
-        var product = jQuery.extend(true, {}, ShoppingCart.currentProduct);
+        // var product = jQuery.extend(true, {}, ShoppingCart.currentProduct);
+        product = jQuery.extend(true, {}, ShoppingCart.currentProduct);
         ShoppingCart.addProduct(product, quantity);
         button.html(window.PLUGIN_SHOPPINGCART.translations.PRODUCT_ADDED_TO_CART);
 

--- a/templates/partials/shoppingcart_core_add_to_cart.html.twig
+++ b/templates/partials/shoppingcart_core_add_to_cart.html.twig
@@ -2,9 +2,12 @@
 
 {{ shoppingcart_output_page_product_before_add_to_cart }}
 
-<a href="#" class="button js__shoppingcart__button-add-to-cart">
+<!-- ** Added ** data-id to bind product with object in currentProducts -->
+<!-- ** Suggestion ** Change link to button. "#" in href is added to url and to the navigation history, and it´s more semantic :) -->
+
+<button type="button" class="button js__shoppingcart__button-add-to-cart" data-id="{{product.id}}">
     <i class="fa fa-shopping-cart"></i> {{ 'PLUGIN_SHOPPINGCART.ADD_TO_CART'|t }}
-</a>
+</button>
 
 <script>
     (function() {
@@ -16,7 +19,12 @@
             url: "{{ product.url }}"
         };
 
-        ShoppingCart.currentProduct = currentProduct;
-        ShoppingCart.currentPageIsProduct = true;
+        // Checks if page is a list of products or single product
+        if (ShoppingCart.currentPageIsProducts) {
+            ShoppingCart.currentProducts.push(currentProduct);
+        } else {
+            ShoppingCart.currentProduct = currentProduct;
+            ShoppingCart.currentPageIsProduct = true;
+        }
     }());
 </script>

--- a/templates/partials/shoppingcart_core_detail_item.html.twig
+++ b/templates/partials/shoppingcart_core_detail_item.html.twig
@@ -1,7 +1,10 @@
 {% set shoppingcart_image = page.media.images|first %}
 {% set image_size_product = config.plugins.shoppingcart.ui.image_size_product %}
 
-{% include 'partials/shoppingcart_core_cart.html.twig' %}
+{# Display only if it hasn't been added in shoppingcart_products.html.twig #}
+{% if not has_cart %}
+    {% include 'partials/shoppingcart_core_cart.html.twig' %}
+{% endif %}
 
 <div id="shoppingcart-detail" class="shoppingcart-product-container block-group">
     <div class="shoppingcart-info block">

--- a/templates/partials/shoppingcart_core_detail_item.html.twig
+++ b/templates/partials/shoppingcart_core_detail_item.html.twig
@@ -1,10 +1,7 @@
 {% set shoppingcart_image = page.media.images|first %}
 {% set image_size_product = config.plugins.shoppingcart.ui.image_size_product %}
 
-{# Display only if it hasn't been added in shoppingcart_products.html.twig #}
-{% if not has_cart %}
-    {% include 'partials/shoppingcart_core_cart.html.twig' %}
-{% endif %}
+{% include 'partials/shoppingcart_core_cart.html.twig' %}
 
 <div id="shoppingcart-detail" class="shoppingcart-product-container block-group">
     <div class="shoppingcart-info block">
@@ -26,7 +23,6 @@
 
             {% set product = { 'title': page.header.title, 'id': md5(page.header.title), 'price': page.header.price, 'image': shoppingcart_image, 'url': page.url } %}
             {% include 'partials/shoppingcart_core_add_to_cart.html.twig' with { product: product } %}
-
         </p>
     </div>
     <div class="shoppingcart-details block">

--- a/templates/partials/shoppingcart_core_product_item.html.twig
+++ b/templates/partials/shoppingcart_core_product_item.html.twig
@@ -18,10 +18,19 @@
     </div>
     <div class="shoppingcart-details">
     <p>
-        <a href="{{ page.url }}"
-            class="button button-small">
-            <i class="fa fa-info-circle"></i> {{ 'PLUGIN_SHOPPINGCART.DETAILS'|t }}
-        </a>
-    </p>
+        {% if page.header.pay_what_you_want %}
+            <a href="{{ page.url }}"
+                class="button button-small">
+                <i class="fa fa-info-circle"></i> {{ 'PLUGIN_SHOPPINGCART.DETAILS'|t }}
+            </a>
+        {% else %}
+            <div class="shoppingcart-quantity-chooser">
+                <label for="js__shoppingcart__quantity">{{ 'PLUGIN_SHOPPINGCART.QUANTITY'|t }}</label>
+                <input type="text" class="small" id="js__shoppingcart__quantity" placeholder="1" value="1" />
+            </div>
+
+            {% set product = { 'title': page.header.title, 'id': md5(page.header.title), 'price': page.header.price, 'image': shoppingcart_image, 'url': page.url } %}
+            {% include 'partials/shoppingcart_core_add_to_cart.html.twig' with { product: product } %}
+        {% endif %}
     </div>
 </div>

--- a/templates/shoppingcart_products.html.twig
+++ b/templates/shoppingcart_products.html.twig
@@ -6,6 +6,8 @@
     <script>
     (function() {
         ShoppingCart.currentPageIsProducts = true;
+        // Define currentProducts.
+        ShoppingCart.currentProducts = [];
     }());
     </script>
 
@@ -17,7 +19,12 @@
         <div class="shoppingcart-products block-group">
             {% for child in page.collection() %}
                 {% if (child.header.unpublished is not defined or (child.header.unpublished == false)) %}
-                    {% include 'partials/shoppingcart_core_product_item.html.twig' with {'page': child, 'parent': page} %}
+                    <!-- Displays template depending on header option -->
+                    {% if page.header.display_add_to_cart %}
+                        {% include 'partials/shoppingcart_core_detail_item.html.twig' with {'page': child, 'parent': page, 'has_cart': true} %}
+                    {% else %}
+                        {% include 'partials/shoppingcart_core_product_item.html.twig' with {'page': child, 'parent': page} %}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         </div>

--- a/templates/shoppingcart_products.html.twig
+++ b/templates/shoppingcart_products.html.twig
@@ -19,12 +19,7 @@
         <div class="shoppingcart-products block-group">
             {% for child in page.collection() %}
                 {% if (child.header.unpublished is not defined or (child.header.unpublished == false)) %}
-                    <!-- Displays template depending on header option -->
-                    {% if page.header.display_add_to_cart %}
-                        {% include 'partials/shoppingcart_core_detail_item.html.twig' with {'page': child, 'parent': page, 'has_cart': true} %}
-                    {% else %}
-                        {% include 'partials/shoppingcart_core_product_item.html.twig' with {'page': child, 'parent': page} %}
-                    {% endif %}
+                    {% include 'partials/shoppingcart_core_product_item.html.twig' with {'page': child, 'parent': page} %}
                 {% endif %}
             {% endfor %}
         </div>


### PR DESCRIPTION
Hi @flaviocopes ,

Here is my pull request for adding Add to cart buttons as an option when displaying multiple products.

I added an option on shopping_products template so you can decide whether you want to display Details or Add to cart button on products. Didn't want to add another template file, the styling is not updated though.