### PR TITLE
Update blueprints fixes #53

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -256,7 +256,7 @@ form:
                   classes: fancy
                   '@data-options': '\Grav\Plugin\ShoppingCart\ShoppingCart::getShippingCountries'
                   validate:
-                    type: commalist
+                    required: true
 
                 .allow:
                   label: Allow


### PR DESCRIPTION
Validating as commalist breaks Country choosing. This fixes it.
I hope this is as intended. Only one Country can be chosen, so we don't need to validate as commalist!