### PR TITLE
Show amount of tax included in Total Price fixes #54

### DIFF
--- a/js/shoppingcart_cart.js
+++ b/js/shoppingcart_cart.js
@@ -184,20 +184,21 @@
         var totalPrice;
         var country = null;
         var tax_percentage = 0;
-	var tax_included = 0;
+        var tax_included = 0;
 
         while (i < ShoppingCart.items.length) {
             orderPrice += ShoppingCart.items[i].product.price * ShoppingCart.items[i].quantity;
             i++;
         }
-		
-	//calculate country taxes
+
+        //calculate country taxes
         var country;
         for (index in ShoppingCart.settings.countries) {
             if (ShoppingCart.checkout_form_data.country == ShoppingCart.settings.countries[index].name) {
                 country = ShoppingCart.settings.countries[index];
             }
         }
+
         if (!country) {
             for (index in ShoppingCart.settings.countries) {
                 if ('*' == ShoppingCart.settings.countries[index].name) {
@@ -206,7 +207,7 @@
             }
         }
 
-	if (country) {
+        if (country) {
             if (country.isAllowed) {
                 tax_percentage = parseInt(country.tax_percentage) || 0;
                 if (country.name === 'US') {
@@ -219,28 +220,25 @@
                 }
             }
         }
-		
+
         if (ShoppingCart.productPriceDoesNotIncludeTaxes()) {
-		if (tax_percentage !== 0) {
-                	totalPrice = orderPrice + orderPrice * (tax_percentage / 100);
-            	} else {
-                	totalPrice = orderPrice;
-            	}
-			
-		totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
-		ShoppingCart.taxesApplied = parseFloat(totalPrice - orderPrice).toFixed(2);
-		ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
-			
+            if (tax_percentage !== 0) {
+                totalPrice = orderPrice + orderPrice * (tax_percentage / 100);
+            } else {
+                totalPrice = orderPrice;
+            }
+
+            totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
+            ShoppingCart.taxesApplied = parseFloat(totalPrice - orderPrice).toFixed(2);
+            ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
         } else {
-            	totalPrice = orderPrice;
-		tax_included = totalPrice * (tax_percentage / 100);
-			
-		totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
-			
-		ShoppingCart.taxesApplied = parseFloat(tax_included).toFixed(2);
-		ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
+            totalPrice = orderPrice;
+            tax_included = totalPrice * (tax_percentage / 100);
+            totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
+            ShoppingCart.taxesApplied = parseFloat(tax_included).toFixed(2);
+            ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
         }
-            
+
         return totalPrice;
     };
 
@@ -599,18 +597,18 @@
 
                 row += '</tr>';
             } else {
-		var amount = ShoppingCart.taxesApplied;
-		row += '<tr class="cart-taxes-calculated">';
-		row += '<td><strong>';
-		row += window.PLUGIN_SHOPPINGCART.translations.TAXES;
-		row += '</strong></td>';
-		row += '<td></td>';
+        var amount = ShoppingCart.taxesApplied;
+        row += '<tr class="cart-taxes-calculated">';
+        row += '<td><strong>';
+        row += window.PLUGIN_SHOPPINGCART.translations.TAXES;
+        row += '</strong></td>';
+        row += '<td></td>';
                 row += '<td></td>';
                 row += '<td>';
-		row += ShoppingCart.renderPriceWithCurrency(amount);
+        row += ShoppingCart.renderPriceWithCurrency(amount);
                 row += '</td>';
-		row += '</tr>';
-		}
+        row += '</tr>';
+        }
 
             /***********************************************************/
             /* Shipping price

--- a/js/shoppingcart_cart.js
+++ b/js/shoppingcart_cart.js
@@ -184,14 +184,14 @@
         var totalPrice;
         var country = null;
         var tax_percentage = 0;
-		var tax_included = 0;
+	var tax_included = 0;
 
         while (i < ShoppingCart.items.length) {
             orderPrice += ShoppingCart.items[i].product.price * ShoppingCart.items[i].quantity;
             i++;
         }
 		
-		//calculate country taxes
+	//calculate country taxes
         var country;
         for (index in ShoppingCart.settings.countries) {
             if (ShoppingCart.checkout_form_data.country == ShoppingCart.settings.countries[index].name) {
@@ -206,7 +206,7 @@
             }
         }
 
-		if (country) {
+	if (country) {
             if (country.isAllowed) {
                 tax_percentage = parseInt(country.tax_percentage) || 0;
                 if (country.name === 'US') {
@@ -221,25 +221,24 @@
         }
 		
         if (ShoppingCart.productPriceDoesNotIncludeTaxes()) {
-            
-            if (tax_percentage !== 0) {
-                totalPrice = orderPrice + orderPrice * (tax_percentage / 100);
-            } else {
-                totalPrice = orderPrice;
-            }
+		if (tax_percentage !== 0) {
+                	totalPrice = orderPrice + orderPrice * (tax_percentage / 100);
+            	} else {
+                	totalPrice = orderPrice;
+            	}
 			
-			totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
-			ShoppingCart.taxesApplied = parseFloat(totalPrice - orderPrice).toFixed(2);
-			ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
+		totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
+		ShoppingCart.taxesApplied = parseFloat(totalPrice - orderPrice).toFixed(2);
+		ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
 			
         } else {
-            totalPrice = orderPrice;
-			tax_included = totalPrice * (tax_percentage / 100);
+            	totalPrice = orderPrice;
+		tax_included = totalPrice * (tax_percentage / 100);
 			
-			totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
+		totalPrice = parseFloat(totalPrice.toFixed(2)).toFixed(2);
 			
-			ShoppingCart.taxesApplied = parseFloat(tax_included).toFixed(2);
-			ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
+		ShoppingCart.taxesApplied = parseFloat(tax_included).toFixed(2);
+		ShoppingCart.totalOrderPriceIncludingTaxes = totalPrice;
         }
             
         return totalPrice;
@@ -600,18 +599,18 @@
 
                 row += '</tr>';
             } else {
-				var amount = ShoppingCart.taxesApplied;
-				row += '<tr class="cart-taxes-calculated">';
-				row += '<td><strong>';
-				row += window.PLUGIN_SHOPPINGCART.translations.TAXES;
-				row += '</strong></td>';
-				row += '<td></td>';
+		var amount = ShoppingCart.taxesApplied;
+		row += '<tr class="cart-taxes-calculated">';
+		row += '<td><strong>';
+		row += window.PLUGIN_SHOPPINGCART.translations.TAXES;
+		row += '</strong></td>';
+		row += '<td></td>';
                 row += '<td></td>';
                 row += '<td>';
-				row += ShoppingCart.renderPriceWithCurrency(amount);
+		row += ShoppingCart.renderPriceWithCurrency(amount);
                 row += '</td>';
-				row += '</tr>';
-			}
+		row += '</tr>';
+		}
 
             /***********************************************************/
             /* Shipping price


### PR DESCRIPTION
This PR adds the enhancement i proposed in #54. It takes the Plugin tax setting into account. If tax is included it will calculate the tax percentage amount included in the total price and renders it to the checkout cart. Tested it myself. Both settings (included & excluded) work as expected. Here's an example:
![tax](https://cloud.githubusercontent.com/assets/16781908/24589234/6ccd9f1c-17d7-11e7-91ca-1a015efc2609.JPG)
