### PR TITLE
Fix #59 ,refix #49

### DIFF
--- a/admin/templates/shoppingcart_orders.html.twig
+++ b/admin/templates/shoppingcart_orders.html.twig
@@ -57,9 +57,9 @@
                                 <strong>Price</strong>:
 
                                 {% if config.plugins.shoppingcart.ui.currency_symbol_position == 'after' %}
-                                    {{ product.product.formatted_price }}{{ currency_symbol }}
+                                    {{ product.product.price }}{{ currency_symbol }}
                                 {% else %}
-                                    {{ currency_symbol }}{{ product.product.formatted_price }}
+                                    {{ currency_symbol }}{{ product.product.price }}
                                 {% endif %}
 
                                 <br>

--- a/templates/partials/shoppingcart_core_add_to_cart.html.twig
+++ b/templates/partials/shoppingcart_core_add_to_cart.html.twig
@@ -1,4 +1,4 @@
-{% set price = product.price|number_format(2, '.', ',') %}
+{% set price = product.price|number_format(2, '.', '') %}
 {% set image_size_cart = config.plugins.shoppingcart.ui.image_size_cart %}
 
 {{ shoppingcart_output_page_product_before_add_to_cart }}
@@ -12,8 +12,7 @@
         var currentProduct = {
             title: "{{ product.title }}",
             id: "{{ product.id }}",
-            formatted_price: "{{ price }}",
-            price: "{{ product.price }}",
+            price: "{{ price }}",
             image: "{{ product.image.cropResize(image_size_cart, image_size_cart).url }}",
             url: "{{ product.url }}"
         };

--- a/templates/partials/shoppingcart_core_price.html.twig
+++ b/templates/partials/shoppingcart_core_price.html.twig
@@ -1,4 +1,4 @@
-{% set formatted_price = price|number_format(2, '.', ',') %}
+{% set formatted_price = price|number_format(2, '.', '') %}
 {% if formatted_price ends with '.00' and config.plugins.shoppingcart.ui.remove_cents_if_zero %}
     {% set formatted_price = price|number_format(0) %}
 {% endif %}


### PR DESCRIPTION
#59 ， when the price is formatted,then the formatted_price maybe not equal to price. for example, price is 37.696, then formated_price will be 37.70, it will cause 'no token passed', especially you use also the discounts plugin.
#49 , the problem is caused by the ,thousands separator ,then the price is over 999, it will have thousands separator ',' , then it is not float, so i removed it. maybe you also need it.