### PR TITLE
Change validate on shipping price from int to number

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -318,7 +318,7 @@ form:
                       type: text
                       help: The price of this shipping option
                       validate:
-                          type: int
+                          type: number
 
         -
           type: tab


### PR DESCRIPTION
The shipping shouldn't be an int since there are times where a decimal shipping can be needed.