### PR TITLE
Fix data exposure problem and other minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v1.2.3
+## 11-08-2018
+
+1. [](#new)
+    * Add option to specify base blueprint to be extended with shoppingcart features (defaults to default)
+1. [](#improved)
+    * improve exclusion tests before merging configuration data
+    * better support for sites with multiple languages 
+    * change taxes and shipping cost from int to number to allow for decimals (see PR by ricardo118 in original repository)
+    * Update available Add-on list
+1. [](#bugfix)
+    * Assure consistent order id
+    * Avoid injection of configuration settings into header of product pages
+    * fix namespace for load_js_globally variable in plugin blueprint
+
 # v1.2.2
 ## 05-05-2017
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Run `cd tests/js` and then `mocha`
 
 Run `composer update` to install the testing dependencies. Then run `composer test` in the root folder
 Then, run `composer update --no-dev` to uninstall the testing dependencies.
+
+### New Master for Shoppingcart
+
+This is the new master of the plugin. The original master can be found at [Shoppingcart](https://github.com/flaviocopes/grav-plugin-shoppingcart)

--- a/admin/templates/shoppingcart_addons.html.twig
+++ b/admin/templates/shoppingcart_addons.html.twig
@@ -15,9 +15,19 @@
         <table>
             <tbody>
                 <tr>
-                    <td colspan="2"><strong>Payment Processing Addons</strong></td>
+                    <td colspan="2"><strong>Feature Addons</strong></td>
+                </tr>                
+                <tr>
+                    <td>Shoppingcart Personalizer</td>
+                    <td>
+                        <a href="https://github.com/leotiger/grav-plugin-shoppingcart-personalizer" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
                 </tr>
-
+                
+                <tr>
+                    <td colspan="2"><strong>Payment Processing Addons</strong></td>
+                </tr>                
                 <tr>
                     <td>PayPal</td>
                     <td>
@@ -32,8 +42,55 @@
                     </td>
                     <td>Free Addon</td>
                 </tr>
+                <tr>
+                    <td>2Checkout</td>
+                    <td>
+                        <a href="https://github.com/NedgoIO/grav-plugin-shoppingcart-twocheckout" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                <tr>
+                    <td>2Checkout Dev</td>
+                    <td>
+                        <a href="https://github.com/weput/grav-plugin-shoppingcart-2checkout-dev" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                <tr>
+                    <td>2Checkout</td>
+                    <td>
+                        <a href="https://github.com/NedgoIO/grav-plugin-shoppingcart-twocheckout" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                <tr>
+                    <td>Pin Checkout</td>
+                    <td>
+                        <a href="https://github.com/absalomedia/grav-plugin-shoppingcart-pin" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                <tr>
+                    <td>Manual checkout</td>
+                    <td>
+                        <a href="https://github.com/koobitor/grav-plugin-shoppingcart-manual-checkout" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                <tr>
+                    <td colspan="2"><strong>Others</strong></td>
+                </tr>                
+                <tr>
+                    <td>Pay what you want</td>
+                    <td>
+                        <a href="https://github.com/hectorromo/grav-plugin-shoppingcart-pay-what-you-want" target="_blank">Link to GitHub</a></a>
+                    </td>
+                    <td>Free Addon</td>
+                </tr>
+                
             </tbody>
         </table>
     </div>
 {% endblock %}
+
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -178,8 +178,6 @@ form:
                   validate:
                     type: string
 
-
-
         -
           type: tab
           title: User Interface
@@ -209,7 +207,6 @@ form:
                 0: PLUGIN_ADMIN.NO
               validate:
                 type: bool
-
 
             ui.use_own_css:
               label: Use plugin's CSS
@@ -277,7 +274,7 @@ form:
                   type: text
                   help: The tax percentage for this country
                   validate:
-                      type: int
+                      type: number
 
         -
           type: tab
@@ -318,7 +315,7 @@ form:
                       type: text
                       help: The price of this shipping option
                       validate:
-                          type: int
+                          type: number
 
         -
           type: tab
@@ -345,6 +342,9 @@ form:
                     checkbox: checkbox
                     email: email
                     toggle: toggle
+                    textarea: textarea
+                    captcha: captcha
+                    spacer: spacer
                   validate:
                     type: string
 
@@ -367,6 +367,24 @@ form:
                   label: Label
                   help:
                   type: text
+                  
+                .title:
+                  toggleable: true
+                  label: Title
+                  help: Only for spacer
+                  type: text
+                  
+                .underline:
+                  toggleable: true
+                  label: Underline
+                  help: Only for spacer
+                  default: 1
+                  type: bool
+                  options:
+                    1: PLUGIN_ADMIN.ENABLED
+                    0: PLUGIN_ADMIN.DISABLED                  
+                  validate:
+                      bool
 
                 .help:
                   toggleable: true

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Shopping Cart
-version: 1.2.2
+version: 1.2.3
 description: "This plugin turns your Grav site into a shopping cart"
 icon: shopping-cart
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -235,6 +235,21 @@ form:
               default: 50
               validate:
                 type: int
+            ui.shoppingcart_product_blueprint:
+              label: Extend product blueprint
+              type: text
+              default: 'default'
+              help: Specify a base blueprint for your product items (must exist in your theme, instance)
+              validate:
+                type: string
+
+            ui.shoppingcart_products_blueprint:
+              label: Extend catalogue blueprint
+              type: text
+              default: 'default'
+              help: Specify a base blueprint for product catalogue (must exist in your theme, instance)
+              validate:
+                type: string
 
         -
           type: tab

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -42,7 +42,7 @@ form:
               validate:
                 type: bool
 
-            load_js_globally:
+            general.load_js_globally:
               label: Load Cart JavaScript globally
               help: Enable if you want the cart to appear on pages different than the shop pages
               type: toggle

--- a/blueprints/pages/shoppingcart_product.yaml
+++ b/blueprints/pages/shoppingcart_product.yaml
@@ -1,7 +1,4 @@
 title: Product
-'@extends':
-    type: default
-    context: blueprints://pages
 
 form:
   fields:

--- a/blueprints/pages/shoppingcart_products.yaml
+++ b/blueprints/pages/shoppingcart_products.yaml
@@ -1,7 +1,4 @@
 title: Products List
-'@extends':
-    type: default
-    context: blueprints://pages
 
 form:
   fields:

--- a/shoppingcart.php
+++ b/shoppingcart.php
@@ -3,8 +3,10 @@ namespace Grav\Plugin;
 
 use Grav\Common\Grav;
 use Grav\Common\Data;
+use Grav\Common\Data\Blueprints;
 use Grav\Common\Filesystem\Folder;
 use Grav\Common\Page\Page;
+use Grav\Common\Page\Pages;
 use Grav\Common\Page\Types;
 use Grav\Common\Plugin;
 use Grav\Common\Twig\Twig;
@@ -622,7 +624,7 @@ class ShoppingcartPlugin extends Plugin
     public function onBlueprintCreated(Event $event)
     {
         $blueprint = $event['blueprint'];
-        $testblueprints = ['shoppingcart_product', 'shoppingcart_products', 'shoppingcart_categories'];
+        $testblueprints = ['shoppingcart_product', 'shoppingcart_products'];
         $bluetest = $this->config->get('plugins.shoppingcart.ui.' . $event['type'] . '_blueprint', 'default');
         if (!in_array($event['type'], $testblueprints)) {
             return;

--- a/shoppingcart.php
+++ b/shoppingcart.php
@@ -490,7 +490,8 @@ class ShoppingcartPlugin extends Plugin
         $prefix = 'order-';
         $format = 'Ymd-His-u';
         $ext = '.yaml';
-        $filename = $prefix . $this->udate($format) . $ext;
+        $udate = $this->udate($format);
+        $filename = $prefix . $udate . $ext;
         $body = Yaml::dump([
             'products'   => $order->products,
             'data'       => $order->data,
@@ -498,8 +499,8 @@ class ShoppingcartPlugin extends Plugin
             'payment'    => $order->payment,
             'token'      => $order->token,
             'paid'       => true,
-            'paid_on'    => $this->udate($format),
-            'created_on' => $this->udate($format),
+            'paid_on'    => $udate,
+            'created_on' => $udate,
             'amount'     => $order->amount,
             'taxes'      => $order->taxes,
         ]);

--- a/shoppingcart.php
+++ b/shoppingcart.php
@@ -43,7 +43,8 @@ class ShoppingcartPlugin extends Plugin
             'onGetPageBlueprints'     => ['onGetPageBlueprints', 0],
             'onGetPageTemplates'      => ['onGetPageTemplates', 0],
             'onShoppingCartSaveOrder' => ['onShoppingCartSaveOrder', 0],
-            'onTwigSiteVariables'     => ['onTwigSiteVariables', 0]
+            'onTwigSiteVariables'     => ['onTwigSiteVariables', 0],
+            'onBlueprintCreated'      => ['onBlueprintCreated', 500],
         ];
     }
 
@@ -612,6 +613,28 @@ class ShoppingcartPlugin extends Plugin
     {
         $this->grav['twig']->twig_paths[] = __DIR__ . '/admin/templates';
     }
-
+   /**
+     * Extend page blueprints with configuration options.
+     *
+     * @param Event $event
+     *
+     */
+    public function onBlueprintCreated(Event $event)
+    {
+        $blueprint = $event['blueprint'];
+        $testblueprints = ['shoppingcart_product', 'shoppingcart_products', 'shoppingcart_categories'];
+        $bluetest = $this->config->get('plugins.shoppingcart.ui.' . $event['type'] . '_blueprint', 'default');
+        if (!in_array($event['type'], $testblueprints)) {
+            return;
+        }
+        $available = Pages::types();
+        $blueprints = new Blueprints(Pages::getTypes());
+        if (array_key_exists($bluetest, $available)) {
+            $extents = $blueprints->get($bluetest);                    
+        } else {                    
+            $extents = $blueprints->get('default');
+        }
+        $blueprint->extend($extents);                
+    }
 
 }


### PR DESCRIPTION
This PR avoids merging the shoppingcart data into pages related with the shopping cart. Add-ons may save the page and developers may be unaware that saving the page object stores also sensitive data like gateway information with the page object. For related page objects the only necessary part is the checkout form. This is injected when the checkout page is called.

Moreover this PR includes a fix for the base url in multi-language environments and some other minor stuff. 